### PR TITLE
Use monospaced digits in value

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "LabeledStepper",
     platforms: [
-        .iOS(.v13),
+        .iOS(.v15),
         // TODO: Should adapt colors for macOS
         // .macOS(.v10_15)
     ],

--- a/Sources/LabeledStepper/LabeledStepper.swift
+++ b/Sources/LabeledStepper/LabeledStepper.swift
@@ -85,6 +85,7 @@ public struct LabeledStepper: View {
                     .padding([.top, .bottom], 8)
 
                 Text("\(value)")
+                    .monospacedDigit()
                     .foregroundColor(style.valueColor)
                     .frame(width: style.labelWidth, height: style.height)
 


### PR DESCRIPTION
Update value `Text` to use monospaced digits using the `.monospacedDigit` view modifier.

Since this is supported from iOS 15,  update of the package iOS version to iOS 15 was done as well.